### PR TITLE
fix(banner): Update locale import and remove settings import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibmdotcom/think-banner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This is a reusable banner to promote the Think event in IBM.com",
   "author": "ibmdotcom-bot",
   "license": "MIT",

--- a/src/components/Banner/Banner.js
+++ b/src/components/Banner/Banner.js
@@ -9,13 +9,11 @@ import React, { Component } from 'react';
 import { ArrowRight24 } from '@carbon/icons-react';
 import { Button } from 'carbon-components-react';
 import BannerAPI from '../../services/Banner/Banner';
-import LocaleAPI from '@carbon/ibmdotcom-services/es/services/Locale/Locale';
-import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
+import { LocaleAPI } from '@carbon/ibmdotcom-services';
 import root from 'window-or-global';
-import settings from 'carbon-components/es/globals/js/settings';
 
-const { stablePrefix } = ddsSettings;
-const { prefix } = settings;
+const stablePrefix = "dds";
+const prefix = "bx";
 
 class Banner extends Component {
 


### PR DESCRIPTION
I was getting a couple errors around importing from these settings files when adding the banner to NextJS templates. Since we're only pulling the two prefixes from these files I moved them directly into the file, and also tweaked how LocaleAPI was imported so it matches what's done in `services/Banner`. 